### PR TITLE
Update twimlApp.js to fix build errors

### DIFF
--- a/util/twimlApp.js
+++ b/util/twimlApp.js
@@ -2,10 +2,9 @@ var twilio = require('twilio');
 var config = require('../config');
 var q = require('q');
 
-// Create reusable Twilio API client
-var client = twilio(config.accountSid, config.authToken);
-
 var getTwimlAppSid = function(appNameToFind) {
+  // Create reusable Twilio API client
+  var client = twilio(config.accountSid, config.authToken);
   var appName = appNameToFind || 'Call tracking app';
 
   if (process.env.TWILIO_APP_SID) {


### PR DESCRIPTION
Twilio is currently invoked before the configuration properties are set. There are a number of different ways this could be fixed, but I'll propose the cleanest in my opinion.