### PR TITLE
Twilio client being initialized before env variables

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,12 +1,15 @@
 var dotenv = require('dotenv');
-var twimlApp = require('./util/twimlApp');
-var cfg = {};
 
+//Check .env variables to load
 if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
   dotenv.config({path: '.env'});
 } else {
   dotenv.config({path: '.env.test', silent: true});
 }
+
+var twimlApp = require('./util/twimlApp');
+var cfg = {};
+
 
 // HTTP Port to run our web application
 cfg.port = process.env.PORT || 3000;


### PR DESCRIPTION
I'm not sure if others have experienced this. The config.js file was loading in the .env variables after calling `var twimlApp = require('./util/twimlApp');`. This was then instantiating the Twilio Client without the API and app credentials triggering this error: `Client requires an Account SID and Auth Token set explicitly`

I moved the `NODE_ENV` conditional above the twimlApp variable declaration to resolve.